### PR TITLE
add support for -O / --optimized-kernel-enable

### DIFF
--- a/analyze_hc_restore.pl
+++ b/analyze_hc_restore.pl
@@ -61,6 +61,7 @@ sub usage
   print "-K | --outfile-check-dir VALUE   Set the --outfile-check-dir to the folder specified by VALUE\n";
   print "-c | --segment-size NUM          Set the --segment-size to NUM\n";
   print "-d | --gpu-devices VALUE         Set the --gpu-devices to the comma-separated list given by VALUE\n";
+  print "-O | --optimized-kernel-enable   Set the --optimized-kernel-enable command line switch\n";
   print "-w | --workload-profile NUM      Set the workload profile to NUM; select between the performance profiles 1 (reduced), 2 (default) or 3 (tuned)\n";
   print "-n | --gpu-accel NUM             Set the gpu acceleration to NUM. 1, 8, 40, 80, 160\n";
   print "-u | --gpu-loops NUM             Set the gpu loops to NUM. 8 - 1024\n";
@@ -742,6 +743,7 @@ my $potfile_disable = "";
 my $logfile_disable = "";
 my $gpu_temp_disable = "";
 my $increment = "";
+my $optimized_kernel = "";
 
 my $runtime_param = "";
 my $session_param = "";
@@ -1067,6 +1069,10 @@ foreach my $arg (@ARGV)
     {
       $switch = "workload-profile";
     }
+    elsif (($arg eq "-O") || ($arg eq "--optimized-kernel-enable"))
+    {
+      $optimized_kernel = "1";
+    }
     elsif (($arg eq "-n") || ($arg eq "--gpu-accel"))
     {
       $switch = "gpu-accel";
@@ -1180,7 +1186,7 @@ if ($input_file eq $output_file)
 
 my $restore_file_modified = 0;
 
-if (($version ne "") || ($cwd ne "") || ($dicts_pos ne "") || ($masks_pos ne "") || ($words_cur ne "") || ($cmd_line ne "") || ($quiet ne "") || ($status ne "") || ($status_automat ne "") || ($outfile_autohex_disable ne "") || ($remove ne "") || ($potfile_disable ne "") || ($logfile_disable ne "") || ($gpu_temp_disable ne "") || ($increment ne "") || ($runtime_param ne "") || ($session_param ne "") || ($outfile_param ne "") || ($outfile_format_param ne "") || ($status_timer_param ne "") || ($outfile_check_timer_param ne "") || ($remove_timer_param ne "") || ($debug_mode_param ne "") || ($debug_file_param ne "") || ($induction_dir_param ne "") || ($outfile_check_dir_param ne "") || ($segment_size_param ne "") || ($gpu_devices_param ne "") || ($workload_profile_param ne "") || ($gpu_accel_param ne "") || ($gpu_loops_param ne "") || ($gpu_temp_abort_param ne "") || ($gpu_temp_retain_param ne "") || ($scrypt_tmto_param ne "") || ($rule_left_param ne "") || ($rule_right_param ne "") || ($rules_file_param ne "") || ($generate_rules_param ne "") || ($custom_charset1_param ne "") || ($custom_charset2_param ne "") || ($custom_charset3_param ne "") || ($custom_charset4_param ne "") || ($increment_min_param ne "") || ($increment_max_param ne "") || ($set_options ne "") || ($remove_options ne ""))
+if (($version ne "") || ($cwd ne "") || ($dicts_pos ne "") || ($masks_pos ne "") || ($words_cur ne "") || ($cmd_line ne "") || ($quiet ne "") || ($status ne "") || ($status_automat ne "") || ($outfile_autohex_disable ne "") || ($remove ne "") || ($potfile_disable ne "") || ($logfile_disable ne "") || ($gpu_temp_disable ne "") || ($increment ne "") || ($optimized_kernel ne "") || ($runtime_param ne "") || ($session_param ne "") || ($outfile_param ne "") || ($outfile_format_param ne "") || ($status_timer_param ne "") || ($outfile_check_timer_param ne "") || ($remove_timer_param ne "") || ($debug_mode_param ne "") || ($debug_file_param ne "") || ($induction_dir_param ne "") || ($outfile_check_dir_param ne "") || ($segment_size_param ne "") || ($gpu_devices_param ne "") || ($workload_profile_param ne "") || ($gpu_accel_param ne "") || ($gpu_loops_param ne "") || ($gpu_temp_abort_param ne "") || ($gpu_temp_retain_param ne "") || ($scrypt_tmto_param ne "") || ($rule_left_param ne "") || ($rule_right_param ne "") || ($rules_file_param ne "") || ($generate_rules_param ne "") || ($custom_charset1_param ne "") || ($custom_charset2_param ne "") || ($custom_charset3_param ne "") || ($custom_charset4_param ne "") || ($increment_min_param ne "") || ($increment_max_param ne "") || ($set_options ne "") || ($remove_options ne ""))
 {
   $restore_file_modified = 1;
 }
@@ -1317,6 +1323,11 @@ if ($restore_file_modified == 1)
       print "\nWARNING: adding --increment to the command line may or may not work in specific cases\n";
 
       add_cmd_line_switch (\%file_info, "--increment");
+    }
+
+    if ($optimized_kernel eq "1")
+    {
+      add_cmd_line_switch (\%file_info, "--optimized-kernel-enable");
     }
 
     # parameters


### PR DESCRIPTION
Tested just with a basic restore, and verified that -O was properly added. 

As they say, "necessity is the mother of invention." :laughing: 